### PR TITLE
single mode for better memory efficiency, actually listen to the conc…

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -96,6 +96,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "mastodon.sidekiq-combined-labels" -}}
+helm.sh/chart: {{ include "mastodon.chart" . }}
+{{ include "mastodon.sidekiq-combined-selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
 {{- define "mastodon.streaming-labels" -}}
 helm.sh/chart: {{ include "mastodon.chart" . }}
 {{ include "mastodon.streaming-selectorLabels" . }}
@@ -140,6 +149,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "mastodon.sidekiq-scheduler-selectorLabels" -}}
 app.kubernetes.io/name: {{ include "mastodon.name" . }}-sidekiq-scheduler
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "mastodon.sidekiq-combined-selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mastodon.name" . }}-sidekiq-combined
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/helm/templates/deployments/sidekiq-default.yaml
+++ b/helm/templates/deployments/sidekiq-default.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sidekiq.singleMode.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +38,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bundle", "exec", "sidekiq", "-c", "25", "-q", "default"]
+          command: ["bundle", "exec", "sidekiq", "-c", "{{ .Values.sidekiq.concurrency }}", "-q", "default"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
@@ -68,3 +69,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/deployments/sidekiq-ingress.yaml
+++ b/helm/templates/deployments/sidekiq-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sidekiq.singleMode.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +38,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bundle", "exec", "sidekiq", "-c", "25", "-q", "ingress"]
+          command: ["bundle", "exec", "sidekiq", "-c", "{{ .Values.sidekiq.concurrency }}", "-q", "ingress"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
@@ -68,3 +69,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/deployments/sidekiq-mailers.yaml
+++ b/helm/templates/deployments/sidekiq-mailers.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sidekiq.singleMode.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +38,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bundle", "exec", "sidekiq", "-c", "25", "-q", "mailers"]
+          command: ["bundle", "exec", "sidekiq", "-c", "{{ .Values.sidekiq.concurrency }}", "-q", "mailers"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
@@ -68,3 +69,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/deployments/sidekiq-pull.yaml
+++ b/helm/templates/deployments/sidekiq-pull.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sidekiq.singleMode.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +38,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bundle", "exec", "sidekiq", "-c", "25", "-q", "pull"]
+          command: ["bundle", "exec", "sidekiq", "-c", "{{ .Values.sidekiq.concurrency }}", "-q", "pull"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
@@ -68,3 +69,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/deployments/sidekiq-push.yaml
+++ b/helm/templates/deployments/sidekiq-push.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sidekiq.singleMode.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +38,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bundle", "exec", "sidekiq", "-c", "25", "-q", "push"]
+          command: ["bundle", "exec", "sidekiq", "-c", "{{ .Values.sidekiq.concurrency }}", "-q", "push"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
@@ -68,3 +69,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/deployments/sidekiq-scheduler.yaml
+++ b/helm/templates/deployments/sidekiq-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+{{- if not .Values.sidekiq.singleMode.enabled }}apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mastodon.fullname" . }}-sidekiq-scheduler
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bundle", "exec", "sidekiq", "-c", "25", "-q", "scheduler"]
+          command: ["bundle", "exec", "sidekiq", "-c", "{{ .Values.sidekiq.concurrency }}", "-q", "scheduler"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
@@ -68,3 +68,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/deployments/web.yaml
+++ b/helm/templates/deployments/web.yaml
@@ -36,7 +36,7 @@ spec:
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh","-c"]
-          args: ["bundle exec rake assets:precompile && bundle exec puma -C config/puma.rb"]
+          args: ["bundle exec puma -C config/puma.rb"]
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -212,6 +212,9 @@ web:
   affinity: {}
 
 sidekiq:
+  # Use a single pod for all queues. Single pod is more memory efficient and multiple pods scale horizontally better
+  singleMode: 
+    enabled: true
   concurrency: 25
   replicas: 1
   autoscaling:


### PR DESCRIPTION
single mode for better memory efficiency, actually listen to the concurrency setting. Allows sidekiq to run as a single pod but will all of the queues active. This reduces memory overhead but also reduces scalability. This setting is on by default and should be changed for large installations.