### PR TITLE
Fix the existingSecret part of the template

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -212,7 +212,7 @@ Get the postgresql secret.
 */}}
 {{- define "mastodon.postgresql.secretName" -}}
 {{- if .Values.mastodon.postgresql.existingSecret }}
-    {{- printf "%s" (tpl .Values.postgresql.existingSecret $) -}}
+    {{- printf "%s" (tpl .Values.mastodon.postgresql.existingSecret $) -}}
 {{- else -}}
     {{- printf "%s" (include "mastodon.fullname" .) -}}
 {{- end -}}


### PR DESCRIPTION
I think there's more that can be done with the secrets stuff but this will at least enable the templates to render with a `mastodon.postgresql.existingSecret` (without duplicating it to two levels).